### PR TITLE
Include device directory path in port name returned by getPortList()

### DIFF
--- a/src/jtermios/linux/JTermiosImpl.java
+++ b/src/jtermios/linux/JTermiosImpl.java
@@ -427,7 +427,7 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 			for (int i = 0; i < devs.length; i++) {
 				String s = devs[i];
 				if (s.startsWith("tty"))
-					list.add(s);
+					list.add(DEVICE_DIR_PATH + s);
 			}
 
 		}

--- a/src/jtermios/linux/JTermiosImpl64b.java
+++ b/src/jtermios/linux/JTermiosImpl64b.java
@@ -422,7 +422,7 @@ public class JTermiosImpl64b implements jtermios.JTermios.JTermiosInterface {
 			for (int i = 0; i < devs.length; i++) {
 				String s = devs[i];
 				if (s.startsWith("tty"))
-					list.add(s);
+					list.add(DEVICE_DIR_PATH + s);
 			}
 
 		}

--- a/src/jtermios/macosx/JTermiosImpl.java
+++ b/src/jtermios/macosx/JTermiosImpl.java
@@ -315,7 +315,7 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 			for (int i = 0; i < devs.length; i++) {
 				String s = devs[i];
 				if (s.startsWith("cu."))
-					list.add(s);
+					list.add(DEVICE_DIR_PATH + s);
 			}
 
 		}


### PR DESCRIPTION
Include device directory path in port name, so that name returned in getPortList can actually be used to select port.  For example on Mac, JTermiosImpl.getPortList() and consequently CommPortIdentifier.getPortIdentifiers().nextElement().getName() currently returns 

cu.Bluetooth-PDA-Sync
cu.Bluetooth-Modem
cu.PL2303-001013FD

However, to use the serial port, I need to use CommPortIdentifier.getPortIdentifier("/dev/cu.PL2303-001013FD").  This change for Mac and Linux means that I can use the name returned by the port identifier to get the port identifier.  I presume it already works for Windows.  In the example above, JTermiosImpl.getPortList() will now return

/dev/cu.Bluetooth-PDA-Sync
/dev/cu.Bluetooth-Modem
/dev/cu.PL2303-001013FD
