### PR TITLE
Make 500000 baud work

### DIFF
--- a/src/purejavacomm/PureJavaSerialPort.java
+++ b/src/purejavacomm/PureJavaSerialPort.java
@@ -38,6 +38,7 @@ import jtermios.*;
 import static jtermios.JTermios.JTermiosLogging.*;
 
 import static jtermios.JTermios.*;
+import com.sun.jna.Platform;
 
 public class PureJavaSerialPort extends SerialPort {
 
@@ -392,80 +393,85 @@ public class PureJavaSerialPort extends SerialPort {
 		prev.set(m_Termios);
 
 		try {
-			int br = baudRate;
-			switch (baudRate) {
-				case 50:
-					br = B50;
-					break;
-				case 75:
-					br = B75;
-					break;
-				case 110:
-					br = B110;
-					break;
-				case 134:
-					br = B134;
-					break;
-				case 150:
-					br = B150;
-					break;
-				case 200:
-					br = B200;
-					break;
-				case 300:
-					br = B300;
-					break;
-				case 600:
-					br = B600;
-					break;
-				case 1200:
-					br = B1200;
-					break;
-				case 1800:
-					br = B1800;
-					break;
-				case 2400:
-					br = B2400;
-					break;
-				case 4800:
-					br = B4800;
-					break;
-				case 9600:
-					br = B9600;
-					break;
-				case 19200:
-					br = B19200;
-					break;
-				case 38400:
-					br = B38400;
-					break;
-				case 7200:
-					br = B7200;
-					break;
-				case 14400:
-					br = B14400;
-					break;
-				case 28800:
-					br = B28800;
-					break;
-				case 57600:
-					br = B57600;
-					break;
-				case 76800:
-					br = B76800;
-					break;
-				case 115200:
-					br = B115200;
-					break;
-				case 230400:
-					br = B230400;
-					break;
+			if (Platform.isMac()) {
+				int[] data = new int[] {baudRate};
+				checkReturnCode(ioctl(m_FD, 0x80045402, data));
+			} else {
+				int br = baudRate;
+				switch (baudRate) {
+					case 50:
+						br = B50;
+						break;
+					case 75:
+						br = B75;
+						break;
+					case 110:
+						br = B110;
+						break;
+					case 134:
+						br = B134;
+						break;
+					case 150:
+						br = B150;
+						break;
+					case 200:
+						br = B200;
+						break;
+					case 300:
+						br = B300;
+						break;
+					case 600:
+						br = B600;
+						break;
+					case 1200:
+						br = B1200;
+						break;
+					case 1800:
+						br = B1800;
+						break;
+					case 2400:
+						br = B2400;
+						break;
+					case 4800:
+						br = B4800;
+						break;
+					case 9600:
+						br = B9600;
+						break;
+					case 19200:
+						br = B19200;
+						break;
+					case 38400:
+						br = B38400;
+						break;
+					case 7200:
+						br = B7200;
+						break;
+					case 14400:
+						br = B14400;
+						break;
+					case 28800:
+						br = B28800;
+						break;
+					case 57600:
+						br = B57600;
+						break;
+					case 76800:
+						br = B76800;
+						break;
+					case 115200:
+						br = B115200;
+						break;
+					case 230400:
+						br = B230400;
+						break;
+				}
+				// try to set the baud rate before anything else
+				// as it may fail at 'tcsetattr' stage and in that
+				// case we do not want to change anything
+				checkReturnCode(cfsetispeed(m_Termios, br));
+				checkReturnCode(cfsetospeed(m_Termios, br));
 			}
-			// try to set the baud rate before anything else
-			// as it may fail at 'tcsetattr' stage and in that
-			// case we do not want to change anything
-			checkReturnCode(cfsetispeed(m_Termios, br));
-			checkReturnCode(cfsetospeed(m_Termios, br));
 
 			int db;
 			switch (dataBits) {


### PR DESCRIPTION
Well, it should work…

```
user=> (def p (.open (purejavacomm.CommPortIdentifier/getPortIdentifier "/dev/tty.usbserial-FTE0ZZ3K") "foobar" 2000))
#'user/p
user=> (.getBaudRate p)
9600
user=> (.setSerialPortParams p 500000 8 1 0)
nil
user=> (.getBaudRate p)
500000
user=> (def is (.getInputStream p))
#'user/is
user=> (def os (.getOutputStream p))
#'user/os
user=> (.write os 4)
nil
user=> (.read is)
; hangs
```

I also tried my improvised loopback device, which did work, but looping works at any rate of course. You would almost think it secretly communicates at 9600.

FYI, this is the Python code:

```
>>> import serial
>>> s = serial.Serial("/dev/tty.usbserial-FTE0ZZ3K", 500000)
>>> s.write(chr(4))
1
>>> s.read(7)
'DPSCOPE'
```
