### PR TITLE
Fix couple of problems I found on windows platform (issues #18 & #19)

### DIFF
--- a/src/jtermios/windows/JTermiosImpl.java
+++ b/src/jtermios/windows/JTermiosImpl.java
@@ -100,7 +100,7 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 		}
 
 		synchronized public void lock() throws InterruptedException {
-			if (m_Locked)
+			while (m_Locked)
 				wait();
 			m_Locked = true;
 		}
@@ -561,7 +561,7 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 		try {
 			if (!SetCommBreak(port.m_Comm))
 				port.fail();
-			nanoSleep(duration * 250000000);
+			nanoSleep(duration * 250000000L);
 			if (!ClearCommBreak(port.m_Comm))
 				port.fail();
 			return 0;

--- a/src/jtermios/windows/WinAPI.java
+++ b/src/jtermios/windows/WinAPI.java
@@ -644,7 +644,7 @@ public class WinAPI {
 
 	static public boolean SetCommBreak(HANDLE hFile) {
 		log = log && log(5, "> SetCommBreak(%s)\n", hFile);
-		boolean res = m_K32lib.CloseHandle(hFile);
+		boolean res = m_K32lib.SetCommBreak(hFile);
 		log = log && log(4, "< SetCommBreak(%s) => %s\n", hFile, res);
 		return res;
 	}


### PR DESCRIPTION
- sendBreak resulted in "timeout value is negative" error
- WinAPI.SetCommBreak mistakenly called CloseHandle
- random "port not locked" caused by problem in JTermiosImpl.lock()

With these fixes, maxim/dallas OneWireAPI for java works ok.
