### PR TITLE
After calling CancelIo, wait for all IO operations to finish before closing handles and freeing OVERLAPPED structures.

### DIFF
--- a/src/jtermios/windows/JTermiosImpl.java
+++ b/src/jtermios/windows/JTermiosImpl.java
@@ -157,7 +157,12 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 						log = log && log(1, "CancelIo() failed, GetLastError()= %d, %s\n", GetLastError(), lineno(1));
 					if (!PurgeComm(m_Comm, PURGE_TXABORT + PURGE_TXCLEAR + PURGE_RXABORT + PURGE_RXCLEAR))
 						log = log && log(1, "PurgeComm() failed, GetLastError()= %d, %s\n", GetLastError(), lineno(1));
+
+					GetOverlappedResult(m_Comm, m_RdOVL, m_RdN, true);
+					GetOverlappedResult(m_Comm, m_WrOVL, m_WrN, true);
+					GetOverlappedResult(m_Comm, m_SelOVL, m_SelN, true);
 				}
+
 				HANDLE h; // / 'hEvent' might never have been 'read' so read it
 				// to this var first
 


### PR DESCRIPTION
This fixes a bug found by Kusti, where a stack corruption could occur when an OVERLAPPED structure is released before all IO operations are finished.
