### PR TITLE
tcsetattr effect is not checked/Handling of termios flags

### DIFF
--- a/src/jtermios/Termios.java
+++ b/src/jtermios/Termios.java
@@ -30,6 +30,8 @@
 
 package jtermios;
 
+import java.util.Arrays;
+
 final public class Termios {
 	public int c_iflag;
 	public int c_oflag;
@@ -45,7 +47,46 @@ final public class Termios {
 		c_lflag=s.c_lflag;
 		System.arraycopy(s.c_cc,0,c_cc,0,c_cc.length);
 		c_ispeed=s.c_ispeed;
-		c_ospeed=s.c_ospeed;
-		
+		c_ospeed=s.c_ospeed;	
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Arrays.hashCode(c_cc);
+		result = prime * result + c_cflag;
+		result = prime * result + c_iflag;
+		result = prime * result + c_ispeed;
+		result = prime * result + c_lflag;
+		result = prime * result + c_oflag;
+		result = prime * result + c_ospeed;
+		return result;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Termios other = (Termios) obj;
+		if (!Arrays.equals(c_cc, other.c_cc))
+			return false;
+		if (c_cflag != other.c_cflag)
+			return false;
+		if (c_iflag != other.c_iflag)
+			return false;
+		if (c_ispeed != other.c_ispeed)
+			return false;
+		if (c_lflag != other.c_lflag)
+			return false;
+		if (c_oflag != other.c_oflag)
+			return false;
+		if (c_ospeed != other.c_ospeed)
+			return false;
+		return true;
 	}
 }

--- a/src/purejavacomm/PureJavaSerialPort.java
+++ b/src/purejavacomm/PureJavaSerialPort.java
@@ -502,6 +502,15 @@ public class PureJavaSerialPort extends SerialPort {
 				if (tcsetattr(m_FD, TCSANOW, m_Termios) != 0)
 					throw new UnsupportedCommOperationException();
 
+				// termios(3) tells us, that tcsetattr succeeds if any change
+				// has been made, not all of them. We'll have to read them back
+				// and check the result
+				Termios changed = new Termios();
+				if (tcgetattr(m_FD, changed) == -1)
+					throw new UnsupportedCommOperationException();
+				if (!changed.equals(m_Termios))
+					throw new UnsupportedCommOperationException();
+				
 				// finally everything went ok, so we can update our settings
 				m_BaudRate = baudRate;
 				m_Parity = parity;


### PR DESCRIPTION
The termios man page explains, that `tcsetattr` succeeds if any changes have been applied, not necessarily all of them.

And some drivers do override `termios` flags if certain features are not supported (`CMSPAR` and the `ti_3140` driver for example), though it's no guarantee that the driver won't silently accept invalid configurations (`ftdi_sio` and `CS6`).

I have a patch for 1.5 stop bit and mark/space parity support which benefit from this patch :innocent:.

However there's a drawback if this would indeed be implemented. Existing users might have never noticed that certain settings didn't work and chances are high that some applications will break.

I would also like to address a strange pattern often seen together with termios: Flags are only masked out or ORed into an existing flag bitfield (e.g. `c_flags`) obtained after opening the port. I would suggest to force all `Termios` flags to 0 or another sane default, because unknown flags can easily influence PJCs operation in a negative way.
