### PR TITLE
Added mark and space parity support

### DIFF
--- a/src/purejavacomm/PureJavaSerialPort.java
+++ b/src/purejavacomm/PureJavaSerialPort.java
@@ -482,6 +482,17 @@ public class PureJavaSerialPort extends SerialPort {
 						fc |= PARODD;
 						fi &= ~(INPCK | ISTRIP);
 						break;
+					case SerialPort.PARITY_MARK:
+						fc |= PARENB;
+						fc |= CMSPAR;
+						fc |= PARODD;
+						fi &= ~(INPCK | ISTRIP);
+						break;
+					case SerialPort.PARITY_SPACE:
+						fc |= PARENB;
+						fc |= CMSPAR;
+						fi &= ~(INPCK | ISTRIP);
+						break;
 					default:
 						throw new UnsupportedCommOperationException("parity = " + parity);
 				}

--- a/src/purejavacomm/testsuite/Test8.java
+++ b/src/purejavacomm/testsuite/Test8.java
@@ -38,7 +38,7 @@ public class Test8 extends TestBase {
 		try {
 			begin("Test8 - parity etc");
 			openPort();
-			int[] parity = { SerialPort.PARITY_NONE, SerialPort.PARITY_ODD, SerialPort.PARITY_EVEN };
+			int[] parity = { SerialPort.PARITY_NONE, SerialPort.PARITY_ODD, SerialPort.PARITY_EVEN, SerialPort.PARITY_MARK, SerialPort.PARITY_SPACE };
 			int[] stopbits = { SerialPort.STOPBITS_1, SerialPort.STOPBITS_1_5, SerialPort.STOPBITS_2 };
 			int[] databits = { SerialPort.DATABITS_8, SerialPort.DATABITS_7, SerialPort.DATABITS_6, SerialPort.DATABITS_5 };
 			int[] datamask = { 0xFF, 0x7F, 0x3F, 0x1F };


### PR DESCRIPTION
Using `CMSPAR`. Verified on Win32 to work with a PL2303 and to be rejected as not supported on Linux x86-64 with a TI 3410.
