### PR TITLE
Make the path to the jna library a relative path instead of an absolute path.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.launching.macosx.MacOSXType/JVM 1.5"/>
-	<classpathentry kind="lib" path="/Users/nyholku/purejavacomm/lib/jna-3.5.1.jar"/>
+	<classpathentry kind="lib" path="lib/jna-3.5.1.jar"/>
 	<classpathentry kind="output" path="classes"/>
 </classpath>


### PR DESCRIPTION
Make the path to the jna library a relative path instead of an absolute path.
