### PR TITLE
Explicitly define minamal Java version 1.5 for Maven compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/maven-archiver/
+bin/maven-status/
 classes/

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,17 @@
 				<artifactId>maven-deploy-plugin</artifactId>
 				<version>2.6</version>
 			</plugin>
+			
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<encoding>UTF-8</encoding>
+					<source>1.5</source>
+					<target>1.5</target>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Hi,

until recently the default Java version used by Maven if nothing else was specified was 1.3. Although the maven-compiler-plugin switched to 1.5 now, my Maven 2 and 3.0.4 installations are still unable to compile purejavacomm out-of-the-box. Therefore, I propose the following fix which explicitly defines the minimum required Java version 1.5, so  compilation works more independent from the actual Maven version.

Thanks,
 -Marco
