### PR TITLE
pull request: write should not block infinitely when in pending

### DIFF
--- a/src/jtermios/windows/JTermiosImpl.java
+++ b/src/jtermios/windows/JTermiosImpl.java
@@ -51,6 +51,8 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 	private volatile boolean m_PortFDs[] = new boolean[FDSetImpl.FD_SET_SIZE];
 
 	private volatile Hashtable<Integer, Port> m_OpenPorts = new Hashtable<Integer, Port>();
+	
+	static final int WRITE_TIMEOUT = 1000;
 
 	private class Port {
 		volatile int m_FD = -1;
@@ -476,22 +478,22 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 		synchronized (port.m_WrBuffer) {
 			try {
 				if (port.m_WritePending > 0) {
-					while (true) {
-						port.m_WriteWaitObjects[0] = port.m_WrOVL.hEvent;
+					port.m_WriteWaitObjects[0] = port.m_WrOVL.hEvent;
 
-						int res = WaitForMultipleObjects(2, port.m_WriteWaitObjects, false, INFINITE);
-						if (res == WAIT_TIMEOUT) { // Hmmm, can this ever happen, why we have that here
-							clearCommErrors(port);
-							log = log && log(1, "write pending, cbInQue %d cbOutQue %d\n", port.m_COMSTAT.cbInQue, port.m_COMSTAT.cbOutQue);
-							continue;
-						}
+					int res = WaitForMultipleObjects(2, port.m_WriteWaitObjects, false, WRITE_TIMEOUT);
+					if (res == WAIT_TIMEOUT) { 
+						// if we have a timeout - return 0 (0 bytes written) as result and try again
+						// this is to prevent an infinite wait here when the connection is broken during a pending
+						clearCommErrors(port);
+						log = log && log(1, "write pending, cbInQue %d cbOutQue %d\n", port.m_COMSTAT.cbInQue, port.m_COMSTAT.cbOutQue);
+						return 0;
+					}
+					else {
 						if (!GetOverlappedResult(port.m_Comm, port.m_WrOVL, port.m_WrN, false))
 							port.fail();
 						if (port.m_WrN[0] != port.m_WritePending) // I exptect this is never going to happen, if it does
 							new RuntimeException("Windows OVERLAPPED WriteFile failed to write all, tried to write " + port.m_WritePending + " but got " + port.m_WrN[0]);
-						break;
 					}
-					port.m_WritePending = 0;
 				}
 				if ((port.m_OpenFlags & O_NONBLOCK) != 0) {
 					if (!ClearCommError(port.m_Comm, port.m_WrErr, port.m_WrStat))


### PR DESCRIPTION
Having a lot of issues with jssc and other serial ports for Java, a colleague found your solution on the internet. I adapted our serial access classes to your purejavacomm - and really works fine.
Except - I get an error in one situation: when there is a lot of traffic to and from the serial interface and the write comes into pending state and in that moment we switch off our device, the write operation hangs completely in the WaitForMultipleObjects(...., INFINITE). So, my first try was to introduce a timeout here, which didn't work yet. But also I added "return 0" and it works like a charm! Now I can plug and unplug the external device as often as I want, and our "ConnectionServer", which handles the serial connections using purejavacomm, never hangs.
Regarding the rest of the code, I don't have a well enough overview to say, if the change I made was correct. So, if you please have a look and send me a small feedback, that'd be great! Thanks!
Sincerely, Michael Schulte
