### PR TITLE
Added 0xFFFFFFFFL & cmd mask to ioctl call in Mac OS X.  Constants be…

### DIFF
--- a/src/jtermios/macosx/JTermiosImpl.java
+++ b/src/jtermios/macosx/JTermiosImpl.java
@@ -554,7 +554,7 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
     }
 
     public int ioctl(int fd, int cmd, int[] data) {
-        return m_Clib.ioctl(fd, new NativeLong(cmd), data);
+        return m_Clib.ioctl(fd, new NativeLong(0xFFFFFFFFL & cmd), data);
     }
 
 	public List<String> getPortList() {


### PR DESCRIPTION
…ing used indicate 32 bit (4 byte) integers are being used as parameters.