### PR TITLE
Added 0xFFFFFFFFL & cmd mask to ioctl call in Mac OS X.

### DIFF
--- a/src/jtermios/JTermios.java
+++ b/src/jtermios/JTermios.java
@@ -38,6 +38,7 @@ import java.util.regex.Pattern;
 import com.sun.jna.Platform;
 import com.sun.jna.Structure;
 import com.sun.jna.IntegerType;
+import com.sun.jna.Native;
 import java.util.*;
 
 /**
@@ -216,6 +217,32 @@ public class JTermios {
         }
 
 	public interface JTermiosInterface {
+                public static class NativeSize extends IntegerType {
+
+                    /**
+                     *
+                     */
+                    private static final long serialVersionUID = 2398288011955445078L;
+                    /**
+                     * Size of a size_t integer, in bytes.
+                     */
+                    public static int SIZE = Native.SIZE_T_SIZE;//Platform.is64Bit() ? 8 : 4;
+
+                    /**
+                     * Create a zero-valued Size.
+                     */
+                    public NativeSize() {
+                        this(SIZE);
+                    }
+
+                    /**
+                     * Create a Size with the given value.
+                     */
+                    public NativeSize(long value) {
+                        super(SIZE, value);
+                    }
+                }
+
                 public FDSet newFDSet();
 
 		int pipe(int[] fds);
@@ -287,10 +314,10 @@ public class JTermios {
                         arglength = 0;
                         return;
                     }
-                    isout = ((inout & 0x4000000) == 0x4000000);
+                    isout = ((inout & 0x40000000) == 0x40000000);
                     arglength = (cmd & 0x1fff0000) >> 16;
                     if (arglength != 4 && arglength != 8)
-                        throw new IllegalArgumentException("ioctl command argument illegal length -> " + arglength);
+                        throw new IllegalArgumentException("ioctl command " + cmd + " argument length illegal -> " + arglength);
                 }
 
                 public Object getArg(int... data) {

--- a/src/jtermios/JTermios.java
+++ b/src/jtermios/JTermios.java
@@ -232,7 +232,7 @@ public class JTermios {
                      * Create a zero-valued Size.
                      */
                     public NativeSize() {
-                        this(SIZE);
+                        this(0);
                     }
 
                     /**

--- a/src/jtermios/JTermios.java
+++ b/src/jtermios/JTermios.java
@@ -37,6 +37,8 @@ import java.util.regex.Pattern;
 
 import com.sun.jna.Platform;
 import com.sun.jna.Structure;
+import com.sun.jna.IntegerType;
+import java.util.*;
 
 /**
  * JTermios provides a limited cross platform unix termios type interface to
@@ -254,7 +256,7 @@ public class JTermios {
 
 		int read(int fd, byte[] buffer, int len);
 
-		int ioctl(int fd, int cmd, int[] data);
+		int ioctl(int fd, int cmd, int... data);
 
 		int select(int n, FDSet read, FDSet write, FDSet error, TimeVal timeout);
 
@@ -271,6 +273,45 @@ public class JTermios {
 		List<String> getPortList();
 
 		public String getPortNamePattern();
+                
+            static public final class ioctl_cmd {
+                public final int command;
+                public final int arglength;
+                public final boolean isout;
+
+                public ioctl_cmd(int cmd) {
+                    command = cmd;
+                    int inout = cmd & 0xe0000000;
+                    if (inout == 0x2000000) {
+                        isout = false;
+                        arglength = 0;
+                        return;
+                    }
+                    isout = ((inout & 0x4000000) == 0x4000000);
+                    arglength = (cmd & 0x1fff0000) >> 16;
+                    if (arglength != 4 && arglength != 8)
+                        throw new IllegalArgumentException("ioctl command argument illegal length -> " + arglength);
+                }
+
+                public Object getArg(int... data) {
+                    if (arglength == 0 || data == null || data.length == 0)
+                        return null;
+
+                    if (data.length > 1)
+                        throw new java.lang.IllegalArgumentException("Only data length of 1 allowed.");
+                    if (isout) {
+                        if (arglength == 4)
+                            return new com.sun.jna.ptr.IntByReference(data[0]);
+                        else
+                            return new com.sun.jna.ptr.LongByReference(data[0]);
+                    } else {
+                        if (arglength == 4)
+                            return Integer.valueOf(data[0]);
+                        else
+                            return Long.valueOf(data[0]);
+                    }
+                }
+            }
 	}
 
 	public void shutdown() {
@@ -412,13 +453,13 @@ public class JTermios {
 		return ret;
 	}
 
-	static public int ioctl(int fd, int cmd, int[] data) {
-		log = log && log(5, "> ioctl(%d,%d,[%08X])\n", fd, cmd, data[0]);
+	static public int ioctl(int fd, int cmd, int... data) {
+		log = log && log(5, "> ioctl(%d,%d,[%08X])\n", fd, cmd, Arrays.toString(data));
 		int ret = m_Termios.ioctl(fd, cmd, data);
-		log = log && log(3, "< ioctl(%d,%d,[%08X]) => %d\n", fd, cmd, data[0], ret);
+		log = log && log(3, "< ioctl(%d,%d,[%08X]) => %d\n", fd, cmd, Arrays.toString(data), ret);
 		return ret;
 	}
-
+        
 	private static String toString(int n, FDSet fdset) {
 		StringBuffer s = new StringBuffer("[");
 		for (int fd = 0; fd < n; fd++)

--- a/src/jtermios/linux/JTermiosImpl.java
+++ b/src/jtermios/linux/JTermiosImpl.java
@@ -628,7 +628,7 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
         return new fd_set();
     }
 
-    public int ioctl(int fd, int cmd, int[] data) {
+    public int ioctl(int fd, int cmd, int... data) {
         return m_Clib.ioctl(fd, cmd, data);
     }
 

--- a/src/jtermios/linux/JTermiosImpl.java
+++ b/src/jtermios/linux/JTermiosImpl.java
@@ -101,32 +101,6 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
                 4000000, 0010017 //
             };
 
-    public static class NativeSize extends IntegerType {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 2398288011955445078L;
-        /**
-         * Size of a size_t integer, in bytes.
-         */
-        public static int SIZE = Native.SIZE_T_SIZE;//Platform.is64Bit() ? 8 : 4;
-
-        /**
-         * Create a zero-valued Size.
-         */
-        public NativeSize() {
-            this(0);
-        }
-
-        /**
-         * Create a Size with the given value.
-         */
-        public NativeSize(long value) {
-            super(SIZE, value);
-        }
-    }
-
     public static class C_lib_DirectMapping implements C_lib {
 
         native public int pipe(int[] fds);
@@ -630,7 +604,7 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
     public int ioctl(int fd, int cmd, int... data) {
         return m_Clib.ioctl(fd, cmd, data);
-    }
+                }
 
     // This ioctl is Linux specific, so keep it private for now
     private int ioctl(int fd, int cmd, serial_struct data) {

--- a/src/jtermios/macosx/JTermiosImpl.java
+++ b/src/jtermios/macosx/JTermiosImpl.java
@@ -59,71 +59,6 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 		m_Clib = m_ClibDM;
 	}
 
-	private final static int TIOCGSERIAL = 0x0000541E;
-	private final static int TIOCSSERIAL = 0x0000541F;
-
-	private final static int ASYNC_SPD_MASK = 0x00001030;
-	private final static int ASYNC_SPD_CUST = 0x00000030;
-
-	private final static int[] m_BaudRates = { //
-	50, 0000001, //
-			75, 0000002, //
-			110, 0000003, //
-			134, 0000004, //
-			150, 0000005, //
-			200, 0000006, //
-			300, 0000007, //
-			600, 0000010, //
-			1200, 0000011, //
-			1800, 0000012, //
-			2400, 0000013, //
-			4800, 0000014, //
-			9600, 0000015, //
-			19200, 0000016, //
-			38400, 0000017, //
-			57600, 0010001, //
-			115200, 0010002, //
-			230400, 0010003, //
-			460800, 0010004, //
-			500000, 0010005, //
-			576000, 0010006, //
-			921600, 0010007, //
-			1000000, 0010010, //
-			1152000, 0010011, //
-			1500000, 0010012, //
-			2000000, 0010013, //
-			2500000, 0010014, //
-			3000000, 0010015, //
-			3500000, 0010016, //
-			4000000, 0010017 //
-	};
-
-	public static class NativeSize extends IntegerType {
-
-		/**
-         *
-         */
-		private static final long serialVersionUID = 2398288011955445078L;
-		/**
-		 * Size of a size_t integer, in bytes.
-		 */
-		public static int SIZE = Native.SIZE_T_SIZE;//Platform.is64Bit() ? 8 : 4;
-
-		/**
-		 * Create a zero-valued Size.
-		 */
-		public NativeSize() {
-			this(0);
-		}
-
-		/**
-		 * Create a Size with the given value.
-		 */
-		public NativeSize(long value) {
-			super(SIZE, value);
-		}
-	}
-
 	public static class C_lib_DirectMapping implements C_lib {
 
 		native public int pipe(int[] fds);
@@ -272,7 +207,7 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
 	static public class fd_set extends Structure implements FDSet {
 
-		private final static int NFBBITS = Integer.SIZE * 8;
+		private final static int NFBBITS = Integer.SIZE;
 		public int fd_count = 1024;
 		public int[] fd_array = new int[fd_count / NFBBITS];
 
@@ -351,112 +286,6 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
 	public JTermiosImpl() {
 		log = log && log(1, "instantiating %s\n", getClass().getCanonicalName());
-
-		//linux/serial.h stuff
-		FIONREAD = 0x541B; // Looked up manually
-		//fcntl.h stuff
-		O_RDWR = 0x00000002;
-		O_NONBLOCK = 0x00000800;
-		O_NOCTTY = 0x00000100;
-		O_NDELAY = 0x00000800;
-		F_GETFL = 0x00000003;
-		F_SETFL = 0x00000004;
-		//errno.h stuff
-		EAGAIN = 11;
-		EACCES = 13;
-		EEXIST = 17;
-		EINTR = 4;
-		EINVAL = 22;
-		EIO = 5;
-		EISDIR = 21;
-		ELOOP = 40;
-		EMFILE = 24;
-		ENAMETOOLONG = 36;
-		ENFILE = 23;
-		ENOENT = 2;
-		ENOSR = 63;
-		ENOSPC = 28;
-		ENOTDIR = 20;
-		ENXIO = 6;
-		EOVERFLOW = 75;
-		EROFS = 30;
-		ENOTSUP = 95;
-		//termios.h stuff
-		TIOCM_RNG = 0x00000080;
-		TIOCM_CAR = 0x00000040;
-		IGNBRK = 0x00000001;
-		BRKINT = 0x00000002;
-		IGNPAR = 0x00000004;
-		PARMRK = 0x00000008;
-		INLCR = 0x00000040;
-		IGNCR = 0x00000080;
-		ICRNL = 0x00000100;
-		ECHONL = 0x00000040;
-		IEXTEN = 0x00008000;
-		CLOCAL = 0x00000800;
-		OPOST = 0x00000001;
-		VSTART = 0x00000008;
-		TCSANOW = 0x00000000;
-		VSTOP = 0x00000009;
-		VMIN = 0x00000006;
-		VTIME = 0x00000005;
-		VEOF = 0x00000004;
-		TIOCMGET = 0x00005415;
-		TIOCM_CTS = 0x00000020;
-		TIOCM_DSR = 0x00000100;
-		TIOCM_RI = 0x00000080;
-		TIOCM_CD = 0x00000040;
-		TIOCM_DTR = 0x00000002;
-		TIOCM_RTS = 0x00000004;
-		ICANON = 0x00000002;
-		ECHO = 0x00000008;
-		ECHOE = 0x00000010;
-		ISIG = 0x00000001;
-		TIOCMSET = 0x00005418;
-		IXON = 0x00000400;
-		IXOFF = 0x00001000;
-		IXANY = 0x00000800;
-		CRTSCTS = 0x80000000;
-		TCSADRAIN = 0x00000001;
-		INPCK = 0x00000010;
-		ISTRIP = 0x00000020;
-		CSIZE = 0x00000030;
-		TCIFLUSH = 0x00000000;
-		TCOFLUSH = 0x00000001;
-		TCIOFLUSH = 0x00000002;
-		CS5 = 0x00000000;
-		CS6 = 0x00000010;
-		CS7 = 0x00000020;
-		CS8 = 0x00000030;
-		CSTOPB = 0x00000040;
-		CREAD = 0x00000080;
-		PARENB = 0x00000100;
-		PARODD = 0x00000200;
-		B0 = 0;
-		B50 = 1;
-		B75 = 2;
-		B110 = 3;
-		B134 = 4;
-		B150 = 5;
-		B200 = 6;
-		B300 = 7;
-		B600 = 8;
-		B1200 = 9;
-		B1800 = 10;
-		B2400 = 11;
-		B4800 = 12;
-		B9600 = 13;
-		B19200 = 14;
-		B38400 = 15;
-		B57600 = 4097;
-		B115200 = 4098;
-		B230400 = 4099;
-		//poll.h stuff
-		POLLIN = 0x0001;
-		POLLPRI = 0x0002;
-		POLLOUT = 0x0004;
-		POLLERR = 0x0008;
-		POLLNVAL = 0x0020;
 	}
 
 	public int errno() {

--- a/src/jtermios/macosx/JTermiosImpl.java
+++ b/src/jtermios/macosx/JTermiosImpl.java
@@ -31,6 +31,7 @@
 package jtermios.macosx;
 
 import com.sun.jna.*;
+import com.sun.jna.ptr.*;
 import java.io.File;
 
 import java.util.*;
@@ -49,10 +50,10 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 	private static String DEVICE_DIR_PATH = "/dev/";
 	static C_lib_DirectMapping m_ClibDM;
 	static C_lib m_Clib;
-	static NonDirectCLib m_ClibND;
+//	static NonDirectCLib m_ClibND;
 
 	static {
-		m_ClibND = (NonDirectCLib) Native.loadLibrary(Platform.C_LIBRARY_NAME, NonDirectCLib.class);
+//		m_ClibND = (NonDirectCLib) Native.loadLibrary(Platform.C_LIBRARY_NAME, NonDirectCLib.class);
 		Native.register(C_lib_DirectMapping.class, NativeLibrary.getInstance(Platform.C_LIBRARY_NAME));
 		m_ClibDM = new C_lib_DirectMapping();
 		m_Clib = m_ClibDM;
@@ -133,7 +134,11 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
 		native public int fcntl(int fd, int cmd, int arg);
 
-		//native public int ioctl(int fd, NativeLong cmd, int[] arg);
+		native public int ioctl(int fd, NativeLong cmd);
+
+		native public int ioctl(int fd, NativeLong cmd, int arg);
+
+		native public int ioctl(int fd, NativeLong cmd, IntByReference arg);
 
 		native public int open(String path, int flags);
 
@@ -175,6 +180,12 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
 		public int fcntl(int fd, int cmd, int arg);
 
+		public int ioctl(int fd, NativeLong cmd);
+
+		public int ioctl(int fd, NativeLong cmd, int arg);
+
+		public int ioctl(int fd, NativeLong cmd, IntByReference arg);
+
 		public int open(String path, int flags);
 
 		public int close(int fd);
@@ -205,12 +216,12 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
 	}
 
-	public interface NonDirectCLib extends com.sun.jna.Library {
-
-		public int ioctl(int fd, NativeLong cmd, NativeLong[] arg);
-
-		//       public int poll(pollfd.ByReference pfds, int nfds, int timeout);
-	}
+//	public interface NonDirectCLib extends com.sun.jna.Library {
+//
+//		public int ioctl(int fd, NativeLong cmd, NativeLong[] arg);
+//
+//		//       public int poll(pollfd.ByReference pfds, int nfds, int timeout);
+//	}
 
 	static public class timeval extends Structure {
 
@@ -553,11 +564,19 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 		return new fd_set();
 	}
 
-	public int ioctl(int fd, int cmd, int[] data) {
-		NativeLong[] dataL = { new NativeLong(data[0]) };
-		int res = m_ClibND.ioctl(fd, new NativeLong(0xFFFFFFFFL & cmd), dataL);
-		data[0] = dataL[0].intValue();
-		return res;
+	public int ioctl(int fd, int cmd, int... data) {
+                // At this time, all ioctl commands we have defined are either no parameter or 4 byte parameter.
+                ioctl_cmd tcmd = new ioctl_cmd(cmd);
+                Object arg = tcmd.getArg(data);
+                if (arg == null)
+                    return m_Clib.ioctl(fd, new NativeLong(0xFFFFFFFFL & cmd));
+                int res;
+                if (arg instanceof IntByReference) {
+                    res = m_Clib.ioctl(fd, new NativeLong(0xFFFFFFFFL & cmd), (IntByReference) arg);
+                    data[0] = ((IntByReference) arg).getValue();
+                    return res;
+                }
+                return m_Clib.ioctl(fd, new NativeLong(0xFFFFFFFFL & cmd), (Integer) arg);
 	}
 
 	public List<String> getPortList() {
@@ -597,10 +616,8 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 			r = tcsetattr(fd, TCSANOW, termios);
 		if (r != 0) {
 			// Darell Tan had patched RXTX with this sequence, so lets try this
-			if (cfsetispeed(termios, B9600) == 0 && cfsetospeed(termios, B9600) == 0 && tcsetattr(fd, TCSANOW, termios) == 0) {
-				int[] data = new int[] { speed };
-				r = ioctl(fd, IOSSIOSPEED, data);
-			}
+			if (cfsetispeed(termios, B9600) == 0 && cfsetospeed(termios, B9600) == 0 && tcsetattr(fd, TCSANOW, termios) == 0)
+				r = ioctl(fd, IOSSIOSPEED, speed);
 		}
 		return r;
 	}

--- a/src/jtermios/solaris/JTermiosImpl.java
+++ b/src/jtermios/solaris/JTermiosImpl.java
@@ -30,6 +30,7 @@
 package jtermios.solaris;
 
 import com.sun.jna.*;
+import com.sun.jna.ptr.IntByReference;
 import java.io.File;
 
 import java.util.*;
@@ -57,72 +58,6 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
         m_Clib = m_ClibDM;
     }
 
-    private final static int TIOCGSERIAL = 0x0000541E;
-    private final static int TIOCSSERIAL = 0x0000541F;
-
-    private final static int ASYNC_SPD_MASK = 0x00001030;
-    private final static int ASYNC_SPD_CUST = 0x00000030;
-
-    private final static int[] m_BaudRates
-            = { //
-                50, 0000001, //
-                75, 0000002, //
-                110, 0000003, //
-                134, 0000004, //
-                150, 0000005, //
-                200, 0000006, //
-                300, 0000007, //
-                600, 0000010, //
-                1200, 0000011, //
-                1800, 0000012, //
-                2400, 0000013, //
-                4800, 0000014, //
-                9600, 0000015, //
-                19200, 0000016, //
-                38400, 0000017, //
-                57600, 0010001, //
-                115200, 0010002, //
-                230400, 0010003, //
-                460800, 0010004, //
-                500000, 0010005, //
-                576000, 0010006, //
-                921600, 0010007, //
-                1000000, 0010010, //
-                1152000, 0010011, //
-                1500000, 0010012, //
-                2000000, 0010013, //
-                2500000, 0010014, //
-                3000000, 0010015, //
-                3500000, 0010016, //
-                4000000, 0010017 //
-            };
-
-    public static class NativeSize extends IntegerType {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 2398288011955445078L;
-        /**
-         * Size of a size_t integer, in bytes.
-         */
-        public static int SIZE = Native.SIZE_T_SIZE;//Platform.is64Bit() ? 8 : 4;
-
-        /**
-         * Create a zero-valued Size.
-         */
-        public NativeSize() {
-            this(0);
-        }
-
-        /**
-         * Create a Size with the given value.
-         */
-        public NativeSize(long value) {
-            super(SIZE, value);
-        }
-    }
-
     public static class C_lib_DirectMapping implements C_lib {
 
         native public int pipe(int[] fds);
@@ -133,7 +68,11 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
         native public int fcntl(int fd, int cmd, int arg);
 
-        native public int ioctl(int fd, int cmd, int[] arg);
+        native public int ioctl(int fd, int cmd);
+
+        native public int ioctl(int fd, int cmd, int arg);
+
+        native public int ioctl(int fd, int cmd, IntByReference arg);
 
         native public int open(String path, int flags);
 
@@ -172,7 +111,11 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
         public int fcntl(int fd, int cmd, int arg);
 
-        public int ioctl(int fd, int cmd, int[] arg);
+        public int ioctl(int fd, int cmd);
+
+        public int ioctl(int fd, int cmd, int arg);
+
+        public int ioctl(int fd, int cmd, IntByReference arg);
 
         public int open(String path, int flags);
 
@@ -337,111 +280,120 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
     public JTermiosImpl() {
         log = log && log(1, "instantiating %s\n", getClass().getCanonicalName());
 
-        //linux/serial.h stuff
-        FIONREAD = 0x541B; // Looked up manually
-        //fcntl.h stuff
-        O_RDWR = 0x00000002;
-        O_NONBLOCK = 0x00000800;
-        O_NOCTTY = 0x00000100;
-        O_NDELAY = 0x00000800;
-        F_GETFL = 0x00000003;
-        F_SETFL = 0x00000004;
-        //errno.h stuff
-        EAGAIN = 11;
-        EACCES = 13;
-        EEXIST = 17;
-        EINTR = 4;
-        EINVAL = 22;
-        EIO = 5;
-        EISDIR = 21;
-        ELOOP = 40;
-        EMFILE = 24;
-        ENAMETOOLONG = 36;
-        ENFILE = 23;
-        ENOENT = 2;
-        ENOSR = 63;
-        ENOSPC = 28;
-        ENOTDIR = 20;
-        ENXIO = 6;
-        EOVERFLOW = 75;
-        EROFS = 30;
-        ENOTSUP = 95;
-        //termios.h stuff
-        TIOCM_RNG = 0x00000080;
-        TIOCM_CAR = 0x00000040;
-        IGNBRK = 0x00000001;
-        BRKINT = 0x00000002;
-        IGNPAR = 0x00000004;
-        PARMRK = 0x00000008;
-        INLCR = 0x00000040;
-        IGNCR = 0x00000080;
-        ICRNL = 0x00000100;
-        ECHONL = 0x00000040;
-        IEXTEN = 0x00008000;
-        CLOCAL = 0x00000800;
-        OPOST = 0x00000001;
-        VSTART = 0x00000008;
-        TCSANOW = 0x00000000;
-        VSTOP = 0x00000009;
-        VMIN = 0x00000006;
-        VTIME = 0x00000005;
-        VEOF = 0x00000004;
-        TIOCMGET = 0x00005415;
-        TIOCM_CTS = 0x00000020;
-        TIOCM_DSR = 0x00000100;
-        TIOCM_RI = 0x00000080;
-        TIOCM_CD = 0x00000040;
-        TIOCM_DTR = 0x00000002;
-        TIOCM_RTS = 0x00000004;
-        ICANON = 0x00000002;
-        ECHO = 0x00000008;
-        ECHOE = 0x00000010;
-        ISIG = 0x00000001;
-        TIOCMSET = 0x00005418;
-        IXON = 0x00000400;
-        IXOFF = 0x00001000;
-        IXANY = 0x00000800;
-        CRTSCTS = 0x80000000;
-        TCSADRAIN = 0x00000001;
-        INPCK = 0x00000010;
-        ISTRIP = 0x00000020;
-        CSIZE = 0x00000030;
-        TCIFLUSH = 0x00000000;
-        TCOFLUSH = 0x00000001;
-        TCIOFLUSH = 0x00000002;
-        CS5 = 0x00000000;
-        CS6 = 0x00000010;
-        CS7 = 0x00000020;
-        CS8 = 0x00000030;
-        CSTOPB = 0x00000040;
-        CREAD = 0x00000080;
-        PARENB = 0x00000100;
-        PARODD = 0x00000200;
-        B0 = 0;
-        B50 = 1;
-        B75 = 2;
-        B110 = 3;
-        B134 = 4;
-        B150 = 5;
-        B200 = 6;
-        B300 = 7;
-        B600 = 8;
-        B1200 = 9;
-        B1800 = 10;
-        B2400 = 11;
-        B4800 = 12;
-        B9600 = 13;
-        B19200 = 14;
-        B38400 = 15;
-        B57600 = 4097;
-        B115200 = 4098;
-        B230400 = 4099;
-        //poll.h stuff
-        POLLIN = 0x0001;
-        POLLPRI = 0x0002;
-        POLLOUT = 0x0004;
-        POLLERR = 0x0008;
-        POLLNVAL = 0x0020;
+		// sys/filio.h stuff
+		FIONREAD = 0x4004667F;
+
+		//fcntl.h stuff
+		O_RDWR = 0x00000002;
+		O_NONBLOCK = 0x00000080;
+		O_NOCTTY = 0x00000800;
+		O_NDELAY = 0x00000004;
+		F_GETFL = 0x00000003;
+		F_SETFL = 0x00000004;
+
+		//errno.h stuff
+		EAGAIN = 11;
+		EBADF = 9;
+		EACCES = 22;
+		EEXIST = 17;
+		EINTR = 4;
+		EINVAL = 22;
+		EIO = 5;
+		EISDIR = 21;
+		ELOOP = 90;
+		EMFILE = 24;
+		ENAMETOOLONG = 78;
+		ENFILE = 23;
+		ENOENT = 2;
+		ENOSR = 63;
+		ENOSPC = 28;
+		ENOTDIR = 20;
+		ENXIO = 6;
+		EOVERFLOW = 79;
+		EROFS = 30;
+		ENOTSUP = 48;
+
+		//termios.h stuff
+		TIOCM_RNG = 0x00000080;
+		TIOCM_CAR = 0x00000040;
+		IGNBRK = 0x00000001;
+		BRKINT = 0x00000002;
+		IGNPAR = 0x00000004;
+		PARMRK = 0x00000008;
+		INLCR = 0x00000040;
+		IGNCR = 0x00000080;
+		ICRNL = 0x00000100;
+		ECHONL = 0x00000040;
+		IEXTEN = 0x00008000;
+		CLOCAL = 0x00000800;
+		OPOST = 0x00000001;
+		VSTART = 0x00000008;
+		TCSANOW = 0x0000540E;
+		VSTOP = 0x00000009;
+		VMIN = 0x00000004;
+		VTIME = 0x00000005;
+		VEOF = 0x00000004;
+		TIOCMGET = 0x0000741D;
+		TIOCM_CTS = 0x00000020;
+		TIOCM_DSR = 0x00000100;
+		TIOCM_RI = 0x00000080;
+		TIOCM_CD = 0x00000040;
+		TIOCM_DTR = 0x00000002;
+		TIOCM_RTS = 0x00000004;
+		ICANON = 0x00000002;
+		ECHO = 0x00000008;
+		ECHOE = 0x00000010;
+		ISIG = 0x00000001;
+		TIOCMSET = 0x0000741A;
+		IXON = 0x00000400;
+		IXOFF = 0x00001000;
+		IXANY = 0x00000800;
+		CRTSCTS = 0x80000000;
+		TCSADRAIN = 0x0000540F;
+		INPCK = 0x00000010;
+		ISTRIP = 0x00000020;
+		CSIZE = 0x00000030;
+		TCIFLUSH = 0x00000000;
+		TCOFLUSH = 0x00000001;
+		TCIOFLUSH = 0x00000002;
+		CS5 = 0x00000000;
+		CS6 = 0x00000010;
+		CS7 = 0x00000020;
+		CS8 = 0x00000030;
+		CSTOPB = 0x00000040;
+		CREAD = 0x00000080;
+		PARENB = 0x00000100;
+		PARODD = 0x00000200;
+		B0 = 0;
+		B50 = 1;
+		B75 = 2;
+		B110 = 3;
+		B134 = 4;
+		B150 = 5;
+		B200 = 6;
+		B300 = 7;
+		B600 = 8;
+		B1200 = 8;
+		B1800 = 10;
+		B2400 = 11;
+		B4800 = 12;
+		B9600 = 13;
+		B19200 = 14;
+		B38400 = 15;
+		B57600 = 16;
+		B76800 = 17;
+		B115200 = 18;
+		B230400 = 20;
+
+		//poll.h stuff
+		POLLIN = 0x0001;
+		POLLPRI = 0x0002;
+		POLLOUT = 0x0004;
+		POLLERR = 0x0008;
+		POLLNVAL = 0x0020;
+
+		//select.h stuff
+
     }
 
     public int errno() {
@@ -562,8 +514,19 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
         return new fd_set();
     }
 
-    public int ioctl(int fd, int cmd, int[] data) {
-        return m_Clib.ioctl(fd, cmd, data);
+    public int ioctl(int fd, int cmd, int... data) {
+                // At this time, all ioctl commands we have defined are either no parameter or 4 byte parameter.
+                ioctl_cmd tcmd = new ioctl_cmd(cmd);
+                Object arg = tcmd.getArg(data);
+                if (arg == null)
+                    return m_Clib.ioctl(fd, cmd);
+                int res;
+                if (arg instanceof IntByReference) {
+                    res = m_Clib.ioctl(fd, cmd, (IntByReference) arg);
+                    data[0] = ((IntByReference) arg).getValue();
+                    return res;
+                }
+                return m_Clib.ioctl(fd, cmd, (Integer) arg);
     }
 
 	public String getPortNamePattern() {

--- a/src/jtermios/windows/JTermiosImpl.java
+++ b/src/jtermios/windows/JTermiosImpl.java
@@ -1024,7 +1024,7 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 		return new FDSetImpl();
 	}
 
-	public int ioctl(int fd, int cmd, int[] arg) {
+	public int ioctl(int fd, int cmd, int... arg) {
 		Port port = getPort(fd);
 		if (port == null)
 			return -1;


### PR DESCRIPTION
Constants being used say that all ioctl args are 4 bytes long (32 bits) so using integer.
Mac code altered to assume int arg values if present and now passing correctly to ioctl (not a pointer if only an IOC_IN arg).  While ioctl code is more complex, it is in line now with the standard definitions for ioctl command interpretation per the Unix and Linux man pages (not including Linux' non-standard use of the serial_struct structure where the upper 16 bits of the command are zero).
No alteration to Windows code.  No alteration to FreeBSD and Solaris until this proves out.