### PR TITLE
Changed fd_set for macosx to match definition in sys/_struct.h

### DIFF
--- a/src/jtermios/macosx/JTermiosImpl.java
+++ b/src/jtermios/macosx/JTermiosImpl.java
@@ -210,7 +210,7 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 		@Override
 		protected List getFieldOrder() {
 			return Arrays.asList(//
-					"fd_count",//
+// per http://www.opensource.apple.com/source/xnu/xnu-1456.1.26/bsd/sys/_structs.h					"fd_count",//
 					"fd_array"//
 			);
 		}


### PR DESCRIPTION
Apple does not include the fd_count field in their definition of fd_set, just the int array.