### PR TITLE
LastErrorException Cleanups for WinAPI

### DIFF
--- a/src/jtermios/windows/JTermiosImpl.java
+++ b/src/jtermios/windows/JTermiosImpl.java
@@ -1128,22 +1128,25 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 		int size = 0;
 		for (size = 16 * 1024; size < 1024 * 1024; size *= 2) {
 			buffer = new byte[size];
-			int res = QueryDosDevice(null, buffer, buffer.length);
-			if (res > 0) { //
-				LinkedList<String> list = new LinkedList<String>();
-				int offset = 0;
-				String port;
-				while ((port = getString(buffer, offset)).length() > 0) {
-					if (p.matcher(port).matches())
-						list.add(port);
+                        try {
+                            if (QueryDosDevice(null, buffer, buffer.length) > 0) { //
+                                    LinkedList<String> list = new LinkedList<String>();
+                                    int offset = 0;
+                                    String port;
+                                    while ((port = getString(buffer, offset)).length() > 0) {
+                                            if (p.matcher(port).matches())
+                                                    list.add(port);
 
-					offset += port.length() + 1;
-				}
-				return list;
-			} else {
-				int err = GetLastError();
-				if (err != ERROR_INSUFFICIENT_BUFFER) {
-					log = log && log(1, "QueryDosDeviceW() failed with GetLastError() = %d\n", err);
+                                            offset += port.length() + 1;
+                                    }
+                                    return list;
+                            } else {
+                                log = log && log(1, "QueryDosDeviceW() failed with GetLastError() = %d\n", 0);
+                                return null;
+                            }
+                        } catch (LastErrorException le) {
+				if (le.getErrorCode() != ERROR_INSUFFICIENT_BUFFER) {
+					log = log && log(1, "QueryDosDeviceW() failed with GetLastError() = %d\n", le.getErrorCode());
 					return null;
 				}
 			}

--- a/src/jtermios/windows/WinAPI.java
+++ b/src/jtermios/windows/WinAPI.java
@@ -140,7 +140,7 @@ public class WinAPI {
 	public static HANDLE NULL = new HANDLE(Pointer.createConstant(0));
 
 	public static class Windows_kernel32_lib_Direct implements Windows_kernel32_lib {
-		native public HANDLE CreateFile(String name, int access, int mode, SECURITY_ATTRIBUTES security, int create, int atteribs, Pointer template) throws LastErrorException;
+		native public HANDLE CreateFile(String name, int access, int mode, SECURITY_ATTRIBUTES security, int create, int atteribs, Pointer template);
 
 		native public boolean WriteFile(HANDLE hFile, byte[] buf, int wrn, int[] nwrtn, Pointer lpOverlapped) throws LastErrorException;
 
@@ -202,7 +202,7 @@ public class WinAPI {
         }
 
         public interface Windows_kernel32_lib extends StdCallLibrary {
-		public HANDLE CreateFile(String name, int access, int mode, SECURITY_ATTRIBUTES security, int create, int atteribs, Pointer template) throws LastErrorException;
+		public HANDLE CreateFile(String name, int access, int mode, SECURITY_ATTRIBUTES security, int create, int atteribs, Pointer template);
 
 		public boolean WriteFile(HANDLE hFile, byte[] buf, int wrn, int[] nwrtn, Pointer lpOverlapped) throws LastErrorException;
 


### PR DESCRIPTION
Removed throws LastErrorException from CreateFile().
Catch LastErrorException in jTermiosImpl.GetPortList().