### PR TITLE
Altered LastError to include both message and error code from LastErr…

### DIFF
--- a/src/jtermios/JTermios.java
+++ b/src/jtermios/JTermios.java
@@ -217,29 +217,22 @@ public class JTermios {
         }
 
 	public interface JTermiosInterface {
-                public static class NativeSize extends IntegerType {
-
-                    /**
-                     *
-                     */
-                    private static final long serialVersionUID = 2398288011955445078L;
-                    /**
-                     * Size of a size_t integer, in bytes.
-                     */
-                    public static int SIZE = Native.SIZE_T_SIZE;//Platform.is64Bit() ? 8 : 4;
-
+                /**
+                 * Signed size_t class so -1 can be checked for
+                 */
+                public static class NativeSize_t extends IntegerType {
                     /**
                      * Create a zero-valued Size.
                      */
-                    public NativeSize() {
+                    public NativeSize_t() {
                         this(0);
                     }
 
                     /**
                      * Create a Size with the given value.
                      */
-                    public NativeSize(long value) {
-                        super(SIZE, value);
+                    public NativeSize_t(long value) {
+                        super(Native.SIZE_T_SIZE, value);
                     }
                 }
 

--- a/src/jtermios/freebsd/JTermiosImpl.java
+++ b/src/jtermios/freebsd/JTermiosImpl.java
@@ -91,9 +91,9 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
         native public NativeLong cfgetospeed(termios termios);
 
-        native public NativeSize write(int fd, byte[] buffer, NativeSize count);
+        native public NativeSize_t write(int fd, byte[] buffer, NativeSize_t count);
 
-        native public NativeSize read(int fd, byte[] buffer, NativeSize count);
+        native public NativeSize_t read(int fd, byte[] buffer, NativeSize_t count);
 
         native public int tcflush(int fd, int qs);
 
@@ -133,9 +133,9 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
         public NativeLong cfgetospeed(termios termios);
 
-        public NativeSize write(int fd, byte[] buffer, NativeSize count);
+        public NativeSize_t write(int fd, byte[] buffer, NativeSize_t count);
 
-        public NativeSize read(int fd, byte[] buffer, NativeSize count);
+        public NativeSize_t read(int fd, byte[] buffer, NativeSize_t count);
 
         public int tcflush(int fd, int qs);
 
@@ -436,11 +436,11 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
     }
 
     public int read(int fd, byte[] buffer, int len) {
-        return m_Clib.read(fd, buffer, new NativeSize(len)).intValue();
+        return m_Clib.read(fd, buffer, new NativeSize_t(len)).intValue();
     }
 
     public int write(int fd, byte[] buffer, int len) {
-        return m_Clib.write(fd, buffer, new NativeSize(len)).intValue();
+        return m_Clib.write(fd, buffer, new NativeSize_t(len)).intValue();
     }
 
     public int close(int fd) {

--- a/src/jtermios/linux/JTermiosImpl.java
+++ b/src/jtermios/linux/JTermiosImpl.java
@@ -132,9 +132,9 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
         native public int cfgetospeed(termios termios);
 
-        native public NativeSize write(int fd, byte[] buffer, NativeSize count);
+        native public NativeSize_t write(int fd, byte[] buffer, NativeSize_t count);
 
-        native public NativeSize read(int fd, byte[] buffer, NativeSize count);
+        native public NativeSize_t read(int fd, byte[] buffer, NativeSize_t count);
 
         native public int tcflush(int fd, int qs);
 
@@ -173,9 +173,9 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
         public int cfgetospeed(termios termios);
 
-        public NativeSize write(int fd, byte[] buffer, NativeSize count);
+        public NativeSize_t write(int fd, byte[] buffer, NativeSize_t count);
 
-        public NativeSize read(int fd, byte[] buffer, NativeSize count);
+        public NativeSize_t read(int fd, byte[] buffer, NativeSize_t count);
 
         public int tcflush(int fd, int qs);
 
@@ -532,11 +532,11 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
     }
 
     public int read(int fd, byte[] buffer, int len) {
-        return m_Clib.read(fd, buffer, new NativeSize(len)).intValue();
+        return m_Clib.read(fd, buffer, new NativeSize_t(len)).intValue();
     }
 
     public int write(int fd, byte[] buffer, int len) {
-        return m_Clib.write(fd, buffer, new NativeSize(len)).intValue();
+        return m_Clib.write(fd, buffer, new NativeSize_t(len)).intValue();
     }
 
     public int close(int fd) {

--- a/src/jtermios/macosx/JTermiosImpl.java
+++ b/src/jtermios/macosx/JTermiosImpl.java
@@ -91,9 +91,9 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
 		native public NativeLong cfgetospeed(termios termios);
 
-		native public NativeSize write(int fd, byte[] buffer, NativeSize count);
+		native public NativeSize_t write(int fd, byte[] buffer, NativeSize_t count);
 
-		native public NativeSize read(int fd, byte[] buffer, NativeSize count);
+		native public NativeSize_t read(int fd, byte[] buffer, NativeSize_t count);
 
 		native public int tcflush(int fd, int qs);
 
@@ -133,9 +133,9 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
 		public NativeLong cfgetospeed(termios termios);
 
-		public NativeSize write(int fd, byte[] buffer, NativeSize count);
+		public NativeSize_t write(int fd, byte[] buffer, NativeSize_t count);
 
-		public NativeSize read(int fd, byte[] buffer, NativeSize count);
+		public NativeSize_t read(int fd, byte[] buffer, NativeSize_t count);
 
 		public int tcflush(int fd, int qs);
 
@@ -331,11 +331,11 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 	}
 
 	public int read(int fd, byte[] buffer, int len) {
-		return m_Clib.read(fd, buffer, new NativeSize(len)).intValue();
+		return m_Clib.read(fd, buffer, new NativeSize_t(len)).intValue();
 	}
 
 	public int write(int fd, byte[] buffer, int len) {
-		return m_Clib.write(fd, buffer, new NativeSize(len)).intValue();
+		return m_Clib.write(fd, buffer, new NativeSize_t(len)).intValue();
 	}
 
 	public int close(int fd) {

--- a/src/jtermios/solaris/JTermiosImpl.java
+++ b/src/jtermios/solaris/JTermiosImpl.java
@@ -87,9 +87,9 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
         native public NativeLong cfgetospeed(termios termios);
 
-        native public NativeSize write(int fd, byte[] buffer, NativeSize count);
+        native public NativeSize_t write(int fd, byte[] buffer, NativeSize_t count);
 
-        native public NativeSize read(int fd, byte[] buffer, NativeSize count);
+        native public NativeSize_t read(int fd, byte[] buffer, NativeSize_t count);
 
         native public int tcflush(int fd, int qs);
 
@@ -126,9 +126,9 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
         public NativeLong cfgetospeed(termios termios);
 
-        public NativeSize write(int fd, byte[] buffer, NativeSize count);
+        public NativeSize_t write(int fd, byte[] buffer, NativeSize_t count);
 
-        public NativeSize read(int fd, byte[] buffer, NativeSize count);
+        public NativeSize_t read(int fd, byte[] buffer, NativeSize_t count);
 
         public int tcflush(int fd, int qs);
 
@@ -436,11 +436,11 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
     }
 
     public int read(int fd, byte[] buffer, int len) {
-        return m_Clib.read(fd, buffer, new NativeSize(len)).intValue();
+        return m_Clib.read(fd, buffer, new NativeSize_t(len)).intValue();
     }
 
     public int write(int fd, byte[] buffer, int len) {
-        return m_Clib.write(fd, buffer, new NativeSize(len)).intValue();
+        return m_Clib.write(fd, buffer, new NativeSize_t(len)).intValue();
     }
 
     public int close(int fd) {

--- a/src/jtermios/windows/JTermiosImpl.java
+++ b/src/jtermios/windows/JTermiosImpl.java
@@ -90,10 +90,10 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
 		synchronized public void fail() throws Fail {
 			int err = GetLastError();
-			Memory buffer = new Memory(2048);
-			FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, null, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, (int) buffer.size(), null);
+//			Memory buffer = new Memory(2048);
+//			FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, null, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer, (int) buffer.size(), null);
 
-			log = log && log(1, "fail() %s, Windows GetLastError()= %d, %s\n", lineno(1), err, buffer.getWideString(0));
+			log = log && log(1, "fail() %s, Windows GetLastError()= %d, %s\n", lineno(1), err, FormatMessage());
 
 			// FIXME here convert from Windows error code to 'posix' error code
 

--- a/src/jtermios/windows/WinAPI.java
+++ b/src/jtermios/windows/WinAPI.java
@@ -99,7 +99,7 @@ public class WinAPI {
         private static FormatMessage m_K32FormatMessage; // Only used for ThreadLocalLastError now to get localized Success message
         static {
             // Moved to static per JNA recommendations
-            Native.setPreserveLastError(true); // For older JNA to hopefully preserve last error although we don't use it with Windows
+// Not needed since using LastErrorException            Native.setPreserveLastError(true); // For older JNA to hopefully preserve last error although we don't use it with Windows
             // This had to be separated out for Direct Mapping (no non-primative arrays)
             m_K32libWM = (WaitMultiple) Native.loadLibrary("kernel32", WaitMultiple.class, com.sun.jna.win32.W32APIOptions.ASCII_OPTIONS);
             // Added com.sun.jna.win32.W32APIOptions.ASCII_OPTIONS so we don't mix/match WString and String


### PR DESCRIPTION
…orException

LastErrorException message is generated from FormatMessageW already so no need to call twice.  Also, use of FormatMessageW with the library loaded using ASCII_OPTIONS might yield unknown results (don't know for sure) so the one call to FormatMessageW (for success, error code 0)  was moved to its own library using the UNICODE_OPTIONS.