### PR TITLE
Fix an issue where connections would hang on read.

### DIFF
--- a/src/purejavacomm/PureJavaSerialPort.java
+++ b/src/purejavacomm/PureJavaSerialPort.java
@@ -1187,7 +1187,7 @@ public class PureJavaSerialPort extends SerialPort {
 								pollfd[0].events = e;
 								pollfd[1].events = POLLIN;
 								if (m_HaveNudgePipe)
-									n = poll(pollfd, 2, -1);
+									n = poll(pollfd, 2, TIMEOUT);
 								else
 									n = poll(pollfd, 1, TIMEOUT);
 


### PR DESCRIPTION
Connections with notifyOnDataAvailable set to true were hanging when there was a nudge pipe, and the pipe was read.  Setting the timeout allows the loop to continue, and processes are correctly notified when data is available.