### PR TITLE
Added nonblocking flag check on create file in windows impl.

### DIFF
--- a/src/jtermios/windows/JTermiosImpl.java
+++ b/src/jtermios/windows/JTermiosImpl.java
@@ -137,7 +137,11 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 						if (!filename.startsWith("\\\\"))
 							filename = "\\\\.\\" + filename;
 
-						m_Comm = CreateFile(filename, GENERIC_READ | GENERIC_WRITE, 0, null, OPEN_EXISTING, FILE_FLAG_OVERLAPPED, null);
+						int openFlags = FILE_ATTRIBUTE_NORMAL;
+						if (((m_OpenFlags & O_NONBLOCK) != 0) || ((m_OpenFlags & O_NDELAY) != 0)) {
+							openFlags = FILE_FLAG_OVERLAPPED;
+						}
+						m_Comm = CreateFile(filename, GENERIC_READ | GENERIC_WRITE, 0, null, OPEN_EXISTING, openFlags, null);
 
 						if (INVALID_HANDLE_VALUE == m_Comm) {
 							if (GetLastError() == ERROR_FILE_NOT_FOUND)
@@ -224,7 +228,7 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
 
 					if (m_WriteCancelObject != null && m_WriteCancelObject != NULL && m_WriteCancelObject != INVALID_HANDLE_VALUE)
 						CloseHandle(m_WriteCancelObject);
-					m_ReadCancelObject = null;
+					m_WriteCancelObject = null;
 				}
 
 				if (WaitCommEventCancelObject != null)

--- a/src/jtermios/windows/WinAPI.java
+++ b/src/jtermios/windows/WinAPI.java
@@ -309,6 +309,7 @@ public class WinAPI {
 	public static final int SETBREAK = 8;
 	public static final int CLRBREAK = 9;
 
+	public static final int FILE_ATTRIBUTE_NORMAL = 0x00000080;
 	public static final int FILE_FLAG_WRITE_THROUGH = 0x80000000;
 	public static final int FILE_FLAG_OVERLAPPED = 0x40000000;
 	public static final int FILE_FLAG_NO_BUFFERING = 0x20000000;


### PR DESCRIPTION
The Windows JTermios implementation didn't honor the non-blocking/no-delay flag. This change fixes that, so the create file call to the Win32 API now results in a blocking read and write when that flag is not present.