### PR TITLE
JTermios OpenBSD Support

### DIFF
--- a/c/c-openbsd.c
+++ b/c/c-openbsd.c
@@ -1,0 +1,242 @@
+// This c.c is NOT part of PureJavaComm, however it can be useful 
+// in porting JTermiosImpl to new platforms
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>    
+#include <termios.h>    
+#include <sys/select.h>    
+#include <poll.h>    
+#include <sys/filio.h>
+
+main(){
+	printf("// sys/filio.h stuff\n");
+	printf("FIONREAD = 0x%08X;\n",FIONREAD);
+
+	printf("// fcntl.h stuff\n");
+	printf("O_RDWR = 0x%08X;\n",O_RDWR);
+	printf("O_NONBLOCK= 0x%08X;\n",O_NONBLOCK);
+	printf("O_NOCTTY = 0x%08X;\n",O_NOCTTY);
+	printf("O_NDELAY = 0x%08X;\n",O_NDELAY);
+	printf("O_CREAT = 0x%08X;\n",O_CREAT);
+	printf("F_GETFL = 0x%08X;\n",F_GETFL);
+	printf("F_SETFL = 0x%08X;\n",F_SETFL);
+
+	printf("// errno.h stuff\n");
+	printf("EAGAIN = %d;\n",EAGAIN);
+	printf("EBADF = %d;\n",EBADF);
+	printf("EACCES= %d;\n",EINVAL);
+	printf("EEXIST= %d;\n",EEXIST);
+	printf("EINTR= %d;\n",EINTR);
+	printf("EINVAL= %d;\n",EINVAL);
+	printf("EIO= %d;\n",EIO);
+	printf("EISDIR= %d;\n",EISDIR);
+	printf("ELOOP= %d;\n",ELOOP);
+	printf("EMFILE= %d;\n",EMFILE);
+	printf("ENAMETOOLONG= %d;\n",ENAMETOOLONG);
+	printf("ENFILE= %d;\n",ENFILE);
+	printf("ENOENT= %d;\n",ENOENT);
+//	printf("ENOSR= %d;\n",ENOSR);
+	printf("ENOSPC= %d;\n",ENOSPC);
+	printf("ENOTDIR= %d;\n",ENOTDIR);
+	printf("ENXIO= %d;\n",ENXIO);
+	printf("EOVERFLOW= %d;\n",EOVERFLOW);
+	printf("EROFS= %d;\n",EROFS);
+	printf("ENOTSUP= %d;\n",ENOTSUP);
+	printf("EBUSY= %d;\n",EBUSY);
+	
+	printf("// termios.h stuff\n");
+	printf("TIOCM_RNG = 0x%08X;\n",TIOCM_RNG);
+	printf("TIOCM_CAR = 0x%08X;\n",TIOCM_CAR);
+	
+	printf("IGNBRK = 0x%08X;\n",IGNBRK);
+	printf("BRKINT = 0x%08X;\n",BRKINT);
+	printf("PARMRK = 0x%08X;\n",PARMRK);
+	printf("INLCR = 0x%08X;\n",INLCR);
+	printf("IGNCR = 0x%08X;\n",IGNCR);
+	printf("ICRNL = 0x%08X;\n",ICRNL); 
+	printf("ECHONL = 0x%08X;\n",ECHONL); 
+	printf("IEXTEN = 0x%08X;\n",IEXTEN);
+	
+	printf("CLOCAL = 0x%08X;\n",CLOCAL);
+	printf("OPOST = 0x%08X;\n",OPOST);
+	printf("VSTART = 0x%08X;\n",VSTART);
+	printf("TCSANOW = 0x%08X;\n",TCSANOW);
+	printf("VSTOP = 0x%08X;\n",VSTOP);
+	printf("VMIN = 0x%08X;\n",VMIN);
+	printf("VTIME = 0x%08X;\n",VTIME);
+	printf("VEOF = 0x%08X;\n",VEOF);
+	printf("TIOCMGET = 0x%08X;\n",TIOCMGET);
+	printf("TIOCM_CTS = 0x%08X;\n",TIOCM_CTS);
+	printf("TIOCM_DSR = 0x%08X;\n",TIOCM_DSR);
+	printf("TIOCM_RI = 0x%08X;\n",TIOCM_RI);
+	printf("TIOCM_CD = 0x%08X;\n",TIOCM_CD);
+	printf("TIOCM_DTR = 0x%08X;\n",TIOCM_DTR);
+	printf("TIOCM_RTS = 0x%08X;\n",TIOCM_RTS);
+	printf("ICANON = 0x%08X;\n",ICANON);
+	printf("ECHO = 0x%08X;\n", ECHO);
+	printf("ECHOE = 0x%08X;\n", ECHOE);
+	printf("ISIG = 0x%08X;\n",ISIG);
+	printf("TIOCMSET= 0x%08X;\n",TIOCMSET);
+	printf("IXON = 0x%08X;\n",IXON);
+	printf("IXOFF = 0x%08X;\n",IXOFF);
+	printf("IXANY = 0x%08X;\n",IXANY);
+//	printf("CNEW_RTSCTS = 0x%08X;\n",CNEW_RTSCTS); // Not availabel on Mac OX X 10.6.6 atleast
+	printf("CRTSCTS = 0x%08X;\n",CRTSCTS);
+	printf("TCSADRAIN = 0x%08X;\n",TCSADRAIN);
+	printf("INPCK = 0x%08X;\n",INPCK);
+	printf("ISTRIP = 0x%08X;\n",ISTRIP);
+	printf("CSIZE = 0x%08X;\n",CSIZE);
+	printf("TCIFLUSH = 0x%08X;\n",TCIFLUSH);
+	printf("TCOFLUSH = 0x%08X;\n",TCOFLUSH);
+	printf("TCIOFLUSH = 0x%08X;\n",TCIOFLUSH);	
+//	printf("TIOCGSERIAL = 0x%08X;\n",TIOCGSERIAL);
+//	printf("TIOCSSERIAL = 0x%08X;\n",TIOCSSERIAL);
+
+//	printf("ASYNC_SPD_MASK = 0x%08X;\n",ASYNC_SPD_MASK);
+//	printf("ASYNC_SPD_CUST = 0x%08X;\n",ASYNC_SPD_CUST);
+
+	
+	
+	printf("CS5 = 0x%08X;\n",CS5);
+	printf("CS6 = 0x%08X;\n",CS6);
+	printf("CS7 = 0x%08X;\n",CS7);
+	printf("CS8 = 0x%08X;\n",CS8);
+
+	printf("CSTOPB = 0x%08X;\n",CSTOPB);
+	printf("CREAD = 0x%08X;\n",CREAD);
+	printf("PARENB = 0x%08X;\n",PARENB);
+	printf("PARODD = 0x%08X;\n",PARODD);
+
+
+	printf("CCTS_OFLOW = 0x%08X;\n",CCTS_OFLOW);
+	printf("CRTS_IFLOW = 0x%08X;\n",CRTS_IFLOW);
+//	printf("CDTR_IFLOW = 0x%08X;\n",CDTR_IFLOW);
+//	printf("CDSR_OFLOW = 0x%08X;\n",CDSR_OFLOW);
+//	printf("CCAR_OFLOW = 0x%08X;\n",CCAR_OFLOW);
+
+	printf("B0 = %d;\n",B0);
+	printf("B50 = %d;\n",B50);
+	printf("B75 = %d;\n",B75);
+	printf("B110 = %d;\n",B110);
+	printf("B134 = %d;\n",B134);
+	printf("B150 = %d;\n",B150);
+	printf("B200 = %d;\n",B200);
+	printf("B300 = %d;\n",B300);
+	printf("B600 = %d;\n",B600);
+	printf("B1200 = %d;\n",B600);
+	printf("B1800 = %d;\n",B1800);
+	printf("B2400 = %d;\n",B2400);
+	printf("B4800 = %d;\n",B4800);
+	printf("B9600 = %d;\n",B9600);
+	printf("B19200 = %d;\n",B19200);
+	printf("B38400 = %d;\n",B38400);
+	printf("B7200 = %d;\n",B7200);
+	printf("B14400 = %d;\n",B14400);
+	printf("B28800 = %d;\n",B28800);
+	printf("B57600 = %d;\n",B57600);
+	printf("B76800 = %d;\n",B76800);
+	printf("B115200 = %d;\n",B115200);
+	printf("B230400 = %d;\n",B230400);
+//	printf("B307200 = %d;\n",B307200);
+//	printf("B460800 = %d;\n",B460800);
+//	printf("B921600 = %d;\n",B921600);
+	
+	printf("// poll.h stuff\n");
+	printf("POLLIN = 0x%04X;\n",POLLIN);
+	printf("POLLRDNORM = 0x%04X;\n",POLLRDNORM);
+	printf("POLLRDBAND = 0x%04X;\n",POLLRDBAND);
+	printf("POLLPRI = 0x%04X;\n",POLLPRI);
+	printf("POLLOUT = 0x%04X;\n",POLLOUT);
+	printf("POLLWRNORM = 0x%04X;\n",POLLWRNORM);
+	printf("POLLWRBAND = 0x%04X;\n",POLLWRBAND);
+	printf("POLLERR = 0x%04X;\n",POLLERR);
+	printf("POLLNVAL = 0x%04X;\n",POLLNVAL);
+
+	
+	printf("// select.h stuff\n");
+	printf("FD_SETSIZE = 0x%08X;\n",FD_SETSIZE);
+	printf("__NFDBITS = 0x%08X;\n",__NFDBITS);
+
+    printf("// _misc\n");
+
+	struct termios t;
+	printf("termios %d\n",sizeof(t));
+	printf(".c_iflag %d\n",((char*)&t.c_iflag)-((char*)&t));	
+	printf(".c_oflag %d\n",((char*)&t.c_oflag)-((char*)&t));
+	printf(".c_cflag %d\n",((char*)&t.c_cflag)-((char*)&t));
+	printf(".c_lflag %d\n",((char*)&t.c_lflag)-((char*)&t));
+//	printf(".c_line %d\n",((char*)&(t.c_line))-((char*)&t));
+	printf(".c_cc[0] %d\n",((char*)&(t.c_cc[0]))-((char*)&t));
+	printf(".c_cc[1] %d\n",((char*)&(t.c_cc[1]))-((char*)&t));
+	printf(".c_cc[30] %d\n",((char*)&(t.c_cc[30]))-((char*)&t));
+	printf(".c_cc[31] %d\n",((char*)&(t.c_cc[31]))-((char*)&t));
+	printf(".c_ispeed %d\n",((char*)&t.c_ispeed)-((char*)&t));
+	printf(".c_ospeed %d\n",((char*)&t.c_ospeed)-((char*)&t));
+
+//	struct serial_struct ss;
+//	printf("serial_struct %d\n",sizeof(ss));
+//	printf(".type %d\n",((char*)&ss.type)-((char*)&ss));
+//	printf(".line %d\n",((char*)&ss.line)-((char*)&ss));
+//	printf(".port %d\n",((char*)&ss.port)-((char*)&ss));
+//	printf(".irq %d\n",((char*)&ss.irq)-((char*)&ss));
+//	printf(".flags %d\n",((char*)&ss.flags)-((char*)&ss));
+//	printf(".xmit_fifo_size %d\n",((char*)&ss.xmit_fifo_size)-((char*)&ss));
+//	printf(".custom_divisor %d\n",((char*)&ss.custom_divisor)-((char*)&ss));
+//	printf(".baud_base %d\n",((char*)&ss.baud_base)-((char*)&ss));
+//	printf(".close_delay %d\n",((char*)&ss.close_delay)-((char*)&ss));
+//	printf(".io_type %d\n",((char*)&ss.io_type)-((char*)&ss));
+//	printf(".reserved_char %d\n",((char*)&ss.reserved_char)-((char*)&ss));
+//	printf(".hub6 %d\n",((char*)&ss.hub6)-((char*)&ss));
+//	printf(".closing_wait %d\n",((char*)&ss.closing_wait)-((char*)&ss));
+//	printf(".closing_wait2 %d\n",((char*)&ss.closing_wait2)-((char*)&ss));
+//	printf(".iomem_base %d\n",((char*)&ss.iomem_base)-((char*)&ss));
+//	printf(".iomem_reg_shift %d\n",((char*)&ss.iomem_reg_shift)-((char*)&ss));
+//	printf(".port_high %d\n",((char*)&ss.port_high)-((char*)&ss));
+//	printf(".iomap_base %d\n",((char*)&ss.iomap_base)-((char*)&ss));
+
+	printf("timeval %d\n",sizeof(struct timeval));
+
+	fd_set fs;
+	FD_ZERO(&fs);
+	FD_SET(41,&fs);
+	printf("sizeof(fd_set)=%d\n",sizeof(fs));
+	int i;
+	for (i=0; i<8; i++)
+		printf("%08X ",fs.fds_bits[i]);
+
+	printf("\n");
+
+	int com;
+	printf("open    %d\n",com =  open("/dev/tty.usbserial-FTOXM3NX", O_RDWR | O_NOCTTY | O_NDELAY));
+
+	struct termios opts;
+
+	printf("get     %d\n",tcgetattr(com, &opts));
+	printf("c_cflag %08X\n",opts.c_cflag);
+
+	opts.c_cflag |= CRTSCTS;
+	printf("c_cflag %08X\n",opts.c_cflag);
+	printf("set     %d\n",tcsetattr(com,TCSANOW, &opts));
+
+	opts.c_cflag = 0;
+	printf("get     %d\n",tcgetattr(com, &opts));
+	printf("c_cflag %08X\n",opts.c_cflag);
+
+	printf(" sizeof(speed_t) %d\n", sizeof(speed_t));
+
+
+
+
+
+
+
+
+
+
+  }

--- a/src/jtermios/JTermios.java
+++ b/src/jtermios/JTermios.java
@@ -322,6 +322,8 @@ public class JTermios {
 			m_Termios = new jtermios.solaris.JTermiosImpl();
 		} else if (Platform.isFreeBSD()) {
 			m_Termios = new jtermios.freebsd.JTermiosImpl();
+		} else if (Platform.isOpenBSD()) {
+			m_Termios = new jtermios.openbsd.JTermiosImpl();
 		} else {
 			log(0, "JTermios has no support for OS %s\n", System.getProperty("os.name"));
 		}

--- a/src/jtermios/openbsd/JTermiosImpl.java
+++ b/src/jtermios/openbsd/JTermiosImpl.java
@@ -1,0 +1,564 @@
+/*
+ * Copyright (c) 2012 Kustaa Nyholm / SpareTimeLabs
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, 
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list 
+ * of conditions and the following disclaimer.
+ * 
+ * Redistributions in binary form must reproduce the above copyright notice, this 
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *  
+ * Neither the name of the Kustaa Nyholm or SpareTimeLabs nor the names of its 
+ * contributors may be used to endorse or promote products derived from this software 
+ * without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, 
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ * 
+ * This FreeBSD backend contributed by Denver Hull 
+ * 
+ * Many thanks for his persistence and efforts to make it happen!
+ * 
+ */
+
+package jtermios.openbsd;
+
+import com.sun.jna.*;
+import jtermios.Pollfd;
+import jtermios.Termios;
+import jtermios.TimeVal;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import static jtermios.JTermios.*;
+import static jtermios.JTermios.JTermiosLogging.log;
+
+public class JTermiosImpl implements JTermiosInterface {
+
+    private static String DEVICE_DIR_PATH = "/dev/";
+    static C_lib_DirectMapping m_ClibDM;
+    static C_lib m_Clib;
+    static NonDirectCLib m_ClibND;
+
+    static {
+        m_ClibND = (NonDirectCLib) Native.loadLibrary(Platform.C_LIBRARY_NAME, NonDirectCLib.class);
+        Native.register(C_lib_DirectMapping.class, NativeLibrary.getInstance(Platform.C_LIBRARY_NAME));
+        m_ClibDM = new C_lib_DirectMapping();
+        m_Clib = m_ClibDM;
+    }
+
+    public static class C_lib_DirectMapping implements C_lib {
+
+        native public int pipe(int[] fds);
+
+        native public int tcdrain(int fd);
+
+        native public void cfmakeraw(termios termios);
+
+        native public int fcntl(int fd, int cmd, int arg);
+
+        native public int ioctl(int fd, int cmd, int[] arg);
+
+        native public int open(String path, int flags);
+
+        native public int close(int fd);
+
+        native public int tcgetattr(int fd, termios termios);
+
+        native public int tcsetattr(int fd, int cmd, termios termios);
+
+        native public int cfsetispeed(termios termios, NativeLong i);
+
+        native public int cfsetospeed(termios termios, NativeLong i);
+
+        native public NativeLong cfgetispeed(termios termios);
+
+        native public NativeLong cfgetospeed(termios termios);
+
+        native public NativeSize write(int fd, byte[] buffer, NativeSize count);
+
+        native public NativeSize read(int fd, byte[] buffer, NativeSize count);
+
+        native public int tcflush(int fd, int qs);
+
+        native public void perror(String msg);
+
+        native public int tcsendbreak(int fd, int duration);
+
+        native public int select(int n, fd_set read, fd_set write, fd_set error, timeval timeout);
+
+    }
+
+    public interface C_lib extends Library {
+
+        public int pipe(int[] fds);
+
+        public int tcdrain(int fd);
+
+        public void cfmakeraw(termios termios);
+
+        public int fcntl(int fd, int cmd, int arg);
+
+        public int ioctl(int fd, int cmd, int[] arg);
+
+        public int open(String path, int flags);
+
+        public int close(int fd);
+
+        public int tcgetattr(int fd, termios termios);
+
+        public int tcsetattr(int fd, int cmd, termios termios);
+
+        public int cfsetispeed(termios termios, NativeLong i);
+
+        public int cfsetospeed(termios termios, NativeLong i);
+
+        public NativeLong cfgetispeed(termios termios);
+
+        public NativeLong cfgetospeed(termios termios);
+
+        public NativeSize write(int fd, byte[] buffer, NativeSize count);
+
+        public NativeSize read(int fd, byte[] buffer, NativeSize count);
+
+        public int tcflush(int fd, int qs);
+
+        public void perror(String msg);
+
+        public int tcsendbreak(int fd, int duration);
+
+        public int select(int n, fd_set read, fd_set write, fd_set error, timeval timeout);
+
+    }
+
+    public interface NonDirectCLib extends Library {
+
+        public int poll(pollfd.ByReference pfds, int nfds, int timeout);
+    }
+
+    static public class timeval extends Structure {
+
+        public NativeLong tv_sec;
+        public NativeLong tv_usec;
+
+        @Override
+        protected List getFieldOrder() {
+            return Arrays.asList(//
+                    "tv_sec",//
+                    "tv_usec"//
+            );
+        }
+
+        public timeval(TimeVal timeout) {
+            tv_sec = new NativeLong(timeout.tv_sec);
+            tv_usec = new NativeLong(timeout.tv_usec);
+        }
+    }
+
+    static public class pollfd extends Structure {
+
+        public static class ByReference extends pollfd implements Structure.ByReference {
+        }
+        public int fd;
+        public short events;
+        public short revents;
+
+        @Override
+        protected List getFieldOrder() {
+            return Arrays.asList(//
+                    "fd",//
+                    "events",//
+                    "revents"//
+            );
+        }
+
+        public pollfd() {
+        }
+
+        public pollfd(Pollfd pfd) {
+            fd = pfd.fd;
+            events = pfd.events;
+            revents = pfd.revents;
+        }
+    }
+
+    static public class fd_set extends Structure implements FDSet {
+
+		private final static int NFBBITS = 32; //__NFDBITS
+		private final static int fd_count = 1024; //FD_SETSIZE
+		public int[] fd_array = new int[(fd_count + NFBBITS - 1) / NFBBITS];
+
+		@Override
+		protected List getFieldOrder() {
+			return Arrays.asList(//
+					"fd_array" //fds_bits
+			);
+		}
+
+		public void FD_SET(int fd) {
+			fd_array[fd / NFBBITS] |= (1 << (fd % NFBBITS));
+		}
+
+		public boolean FD_ISSET(int fd) {
+			return (fd_array[fd / NFBBITS] & (1 << (fd % NFBBITS))) != 0;
+		}
+
+		public void FD_ZERO() {
+			Arrays.fill(fd_array, 0);
+		}
+
+		public void FD_CLR(int fd) {
+			fd_array[fd / NFBBITS] &= ~(1 << (fd % NFBBITS));
+		}
+
+    }
+
+    static public class termios extends Structure {
+
+        public int c_iflag;
+        public int c_oflag;
+        public int c_cflag;
+        public int c_lflag;
+        public byte[] c_cc = new byte[20];
+        public int c_ispeed;
+        public int c_ospeed;
+
+        @Override
+        protected List getFieldOrder() {
+            return Arrays.asList(//
+                    "c_iflag",//
+                    "c_oflag",//
+                    "c_cflag",//
+                    "c_lflag",//
+                    "c_cc",//
+                    "c_ispeed",//
+                    "c_ospeed"//
+            );
+        }
+
+        public termios() {
+        }
+
+        public termios(Termios t) {
+            c_iflag = t.c_iflag;
+            c_oflag = t.c_oflag;
+            c_cflag = t.c_cflag;
+            System.arraycopy(t.c_cc, 0, c_cc, 0, Math.min(t.c_cc.length, c_cc.length));
+            c_ispeed = t.c_ispeed;
+            c_ospeed = t.c_ospeed;
+        }
+
+        public void update(Termios t) {
+            t.c_iflag = c_iflag;
+            t.c_oflag = c_oflag;
+            t.c_cflag = c_cflag;
+            System.arraycopy(c_cc, 0, t.c_cc, 0, Math.min(t.c_cc.length, c_cc.length));
+            t.c_ispeed = c_ispeed;
+            t.c_ospeed = c_ospeed;
+        }
+    }
+
+    public JTermiosImpl() {
+        log = log && log(1, "instantiating %s\n", getClass().getCanonicalName());
+
+        // sys/filio.h stuff
+        FIONREAD = 0x4004667F;
+        // fcntl.h stuff
+        O_RDWR = 0x00000002;
+        O_NONBLOCK = 0x00000004;
+        O_NOCTTY = 0x00008000;
+        O_NDELAY = 0x00000004;
+        O_CREAT = 0x00000200;
+        F_GETFL = 0x00000003;
+        F_SETFL = 0x00000004;
+        // errno.h stuff
+        EAGAIN = 35;
+        EBADF = 9;
+        EACCES = 22;
+        EEXIST = 17;
+        EINTR = 4;
+        EINVAL = 22;
+        EIO = 5;
+        EISDIR = 21;
+        ELOOP = 62;
+        EMFILE = 24;
+        ENAMETOOLONG = 63;
+        ENFILE = 23;
+        ENOENT = 2;
+        ENOSPC = 28;
+        ENOTDIR = 20;
+        ENXIO = 6;
+        EOVERFLOW = 87;
+        EROFS = 30;
+        ENOTSUP = 91;
+        EBUSY = 16;
+        // termios.h stuff
+        TIOCM_RNG = 0x00000080;
+        TIOCM_CAR = 0x00000040;
+        IGNBRK = 0x00000001;
+        BRKINT = 0x00000002;
+        PARMRK = 0x00000008;
+        INLCR = 0x00000040;
+        IGNCR = 0x00000080;
+        ICRNL = 0x00000100;
+        ECHONL = 0x00000010;
+        IEXTEN = 0x00000400;
+        CLOCAL = 0x00008000;
+        OPOST = 0x00000001;
+        VSTART = 0x0000000C;
+        TCSANOW = 0x00000000;
+        VSTOP = 0x0000000D;
+        VMIN = 0x00000010;
+        VTIME = 0x00000011;
+        VEOF = 0x00000000;
+        TIOCMGET = 0x4004746A;
+        TIOCM_CTS = 0x00000020;
+        TIOCM_DSR = 0x00000100;
+        TIOCM_RI = 0x00000080;
+        TIOCM_CD = 0x00000040;
+        TIOCM_DTR = 0x00000002;
+        TIOCM_RTS = 0x00000004;
+        ICANON = 0x00000100;
+        ECHO = 0x00000008;
+        ECHOE = 0x00000002;
+        ISIG = 0x00000080;
+        TIOCMSET = 0x8004746D;
+        IXON = 0x00000200;
+        IXOFF = 0x00000400;
+        IXANY = 0x00000800;
+        CRTSCTS = 0x00010000;
+        TCSADRAIN = 0x00000001;
+        INPCK = 0x00000010;
+        ISTRIP = 0x00000020;
+        CSIZE = 0x00000300;
+        TCIFLUSH = 0x00000001;
+        TCOFLUSH = 0x00000002;
+        TCIOFLUSH = 0x00000003;
+        CS5 = 0x00000000;
+        CS6 = 0x00000100;
+        CS7 = 0x00000200;
+        CS8 = 0x00000300;
+        CSTOPB = 0x00000400;
+        CREAD = 0x00000800;
+        PARENB = 0x00001000;
+        PARODD = 0x00002000;
+//      CCTS_OFLOW = 0x00010000
+//      CRTS_IFLOW = 0x00010000;
+        B0 = 0;
+        B50 = 50;
+        B75 = 75;
+        B110 = 110;
+        B134 = 134;
+        B150 = 150;
+        B200 = 200;
+        B300 = 300;
+        B600 = 600;
+        B1200 = 600;
+        B1800 = 1800;
+        B2400 = 2400;
+        B4800 = 4800;
+        B9600 = 9600;
+        B19200 = 19200;
+        B38400 = 38400;
+        B7200 = 7200;
+        B14400 = 14400;
+        B28800 = 28800;
+        B57600 = 57600;
+        B76800 = 76800;
+        B115200 = 115200;
+        B230400 = 230400;
+        // poll.h stuff
+        POLLIN = 0x0001;
+//      POLLRDNORM = 0x0040;
+//      POLLRDBAND = 0x0080;
+        POLLPRI = 0x0002;
+        POLLOUT = 0x0004;
+//      POLLWRNORM = 0x0004;
+//      POLLWRBAND = 0x0100;
+        POLLERR = 0x0008;
+        POLLNVAL = 0x0020;
+        // select.h stuff
+//      FD_SETSIZE = 0x00000400;
+    }
+
+    public int errno() {
+        return Native.getLastError();
+    }
+
+    public void cfmakeraw(Termios termios) {
+        termios t = new termios(termios);
+        m_Clib.cfmakeraw(t);
+        t.update(termios);
+    }
+
+    public int fcntl(int fd, int cmd, int arg) {
+        return m_Clib.fcntl(fd, cmd, arg);
+    }
+
+    public int tcdrain(int fd) {
+        return m_Clib.tcdrain(fd);
+    }
+
+    public int cfgetispeed(Termios termios) {
+        return m_Clib.cfgetispeed(new termios(termios)).intValue();
+    }
+
+    public int cfgetospeed(Termios termios) {
+        return m_Clib.cfgetospeed(new termios(termios)).intValue();
+    }
+
+    public int cfsetispeed(Termios termios, int speed) {
+        termios t = new termios(termios);
+        int ret = m_Clib.cfsetispeed(t, new NativeLong(speed));
+        t.update(termios);
+        return ret;
+    }
+
+    public int cfsetospeed(Termios termios, int speed) {
+        termios t = new termios(termios);
+        int ret = m_Clib.cfsetospeed(t, new NativeLong(speed));
+        t.update(termios);
+        return ret;
+    }
+
+    public int open(String s, int t) {
+        if (s != null && !s.startsWith("/")) {
+            s = DEVICE_DIR_PATH + s;
+        }
+        return m_Clib.open(s, t);
+    }
+
+    public int read(int fd, byte[] buffer, int len) {
+        return m_Clib.read(fd, buffer, new NativeSize(len)).intValue();
+    }
+
+    public int write(int fd, byte[] buffer, int len) {
+        return m_Clib.write(fd, buffer, new NativeSize(len)).intValue();
+    }
+
+    public int close(int fd) {
+        return m_Clib.close(fd);
+    }
+
+    public int tcflush(int fd, int b) {
+        return m_Clib.tcflush(fd, b);
+    }
+
+    public int tcgetattr(int fd, Termios termios) {
+        termios t = new termios();
+        int ret = m_Clib.tcgetattr(fd, t);
+        t.update(termios);
+        return ret;
+    }
+
+    public void perror(String msg) {
+        m_Clib.perror(msg);
+    }
+
+    public int tcsendbreak(int fd, int duration) {
+        // If duration is not zero, it sends zero-valued bits for duration*N seconds,
+        // where N is at least 0.25, and not more than 0.5.
+        return m_Clib.tcsendbreak(fd, duration / 250);
+    }
+
+    public int tcsetattr(int fd, int cmd, Termios termios) {
+        return m_Clib.tcsetattr(fd, cmd, new termios(termios));
+    }
+
+    public int select(int nfds, FDSet rfds, FDSet wfds, FDSet efds, TimeVal timeout) {
+        timeval tout = null;
+        if (timeout != null) {
+            tout = new timeval(timeout);
+        }
+
+        return m_Clib.select(nfds, (fd_set) rfds, (fd_set) wfds, (fd_set) efds, tout);
+    }
+
+    public int poll(Pollfd fds[], int nfds, int timeout) {
+        if (nfds <= 0 || nfds > fds.length) {
+            throw new IllegalArgumentException("nfds " + nfds + " must be <= fds.length " + fds.length);
+        }
+        pollfd.ByReference parampfds = new pollfd.ByReference();
+        pollfd[] pfds = (pollfd[]) parampfds.toArray(nfds);
+        for (int i = 0; i < nfds; i++) {
+            pfds[i].fd = fds[i].fd;
+            pfds[i].events = fds[i].events;
+        }
+        int ret = m_ClibND.poll(parampfds, nfds, timeout);
+        for (int i = 0; i < nfds; i++) {
+            fds[i].revents = pfds[i].revents;
+        }
+        return ret;
+    }
+
+    public boolean canPoll() {
+        return true;
+    }
+
+    public FDSet newFDSet() {
+        return new fd_set();
+    }
+
+    public int ioctl(int fd, int cmd, int... data) {
+                // At this time, all ioctl commands we have defined are either no parameter or 4 byte parameter.
+                return m_Clib.ioctl(fd, cmd, data);
+    }
+
+	public List<String> getPortList() {
+		File dir = new File(DEVICE_DIR_PATH);
+		if (!dir.isDirectory()) {
+			log = log && log(1, "device directory %s does not exist\n", DEVICE_DIR_PATH);
+			return null;
+		}
+		String[] devs = dir.list();
+		LinkedList<String> list = new LinkedList<String>();
+		if (devs != null) {
+			for (int i = 0; i < devs.length; i++) {
+				String s = devs[i];
+				if (s.startsWith("cua") || s.startsWith("tty"))
+					list.add(s);
+			}
+
+		}
+
+		return list;
+	}
+
+	public void shutDown() {
+
+	}
+
+	public String getPortNamePattern() {
+		return "^(tty\\.|cu\\.).*";
+	}
+
+	public int setspeed(int fd, Termios termios, int speed) {
+		int r;
+		r = cfsetispeed(termios, speed);
+		if (r == 0)
+			r = cfsetospeed(termios, speed);
+		if (r == 0)
+			r = tcsetattr(fd, TCSANOW, termios);
+		return r;
+	}
+
+	public int pipe(int[] fds) {
+		return m_Clib.pipe(fds);
+	}
+
+}


### PR DESCRIPTION
This pull request will add OpenBSD support to JTermios

c-openbsd.c has been created by patching together the other c-*.c files
JTermiosImpl.java is a copy of the freebsd's one using platform specific values for the constants
JTermios.java has been edited in a self explanatory way

TestSuite.java passes all tests (using an emulated serial port with socat)
TwoPortSerialTest.java hasn't been tried because I don't understand what that is

I'm making this request because intellij idea's terminal plugin is not working and the log says "JTermios has no support for OS OpenBSD"

Thank you and have a good day