### PR TITLE
Linux GLIBC 2.42 changes the definition of speed_t to be actual baud …

### DIFF
--- a/LINUX-GLIBC.md
+++ b/LINUX-GLIBC.md
@@ -1,0 +1,17 @@
+When using PureJavaComm on Linux there is a breaking change in the native API for the GNU C LIbrary (glibc) version 2.42 (and higher)
+
+To quote from the release notes here [The GNU C Library version 2.42 is now available](https://lists.gnu.org/archive/html/info-gnu/2025-07/msg00011.html)
+
+>On Linux, the <termios.h> interface now supports arbitrary baud rates;
+>speed_t is redefined to simply be the baud rate specified as an
+>unsigned int, which matches the kernel interface.
+
+Prior to this change, the actual speed was set by an int code that was mapped to the required speed.
+
+These int codes were defined in m_BaudRates in [JTermiosImpl.java](src/jtermios/linux/JTermiosImpl.java) and the `setSpeed` method in there
+performed a lookup of the requested speed (e.g. 9600 baud) to the flag (e.g. 0000015).  This flag value was then passed to the native code
+structure.
+
+After this change, as detailed in the quote, the speed_t value should just be the required baud rate, e.g. 9600 baud.
+
+Compatibility with glibc 2.42 and higher can be achieved by running your program with `-Djtermios.modern.speed=true` as an argument to the JVM.

--- a/src/jtermios/linux/JTermiosImpl.java
+++ b/src/jtermios/linux/JTermiosImpl.java
@@ -53,12 +53,14 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
     static C_lib_DirectMapping m_ClibDM;
     static C_lib m_Clib;
     static NonDirectCLib m_ClibND;
+    static boolean modernSpeedSetting;
 
     static {
         m_ClibND = (NonDirectCLib) Native.loadLibrary(Platform.C_LIBRARY_NAME, NonDirectCLib.class);
         Native.register(C_lib_DirectMapping.class, NativeLibrary.getInstance(Platform.C_LIBRARY_NAME));
         m_ClibDM = new C_lib_DirectMapping();
         m_Clib = m_ClibDM;
+        modernSpeedSetting=Boolean.parseBoolean(System.getProperty("jtermios.modern.speed", "false"));
     }
 
     private final static int TIOCGSERIAL = 0x0000541E;
@@ -713,8 +715,11 @@ public class JTermiosImpl implements jtermios.JTermios.JTermiosInterface {
                     r = ioctl(fd, TIOCSSERIAL, ss);
                 }
 
-                // now set the speed with the constant from the table
-                c = m_BaudRates[i + 1];
+                // now set the speed with the constant from the table - or not, if modern speed setting
+                if( ! modernSpeedSetting ) {
+                    c = m_BaudRates[i + 1];
+                    log = log && log(1, "Using legacy flag %d to set speed %d\n", c, speed);
+                }
                 if ((r = JTermios.cfsetispeed(termios, c)) != 0) {
                     return r;
                 }


### PR DESCRIPTION
…rate #144

In Linux, some variants, including at least Fedora 43 are using GLIBC 2.42 .  In this release, the definition of speed_t for setting the baud rate has been changed to the actual baud rate, rather than the legacy flags.  This PR allows PureJavaComm to work with these values by introducing a runtime boolean set by

`-Djtermios.modern.speed=true`

in the JVM arguments.  If this is set to true, the requested speed (e.g. 9600) is passed to the native code call, rather than the corresponding flag (0000015).